### PR TITLE
fix fullWidth to be working as expected

### DIFF
--- a/lib/widget/base.dart
+++ b/lib/widget/base.dart
@@ -775,12 +775,10 @@ extension BaseProperty on Niku {
   /// ```
   /// SizedBox(
   ///   width: double.infinity,
-  ///   height: double.infinity
   /// )
   /// ```
   Niku fullWidth() {
-    _widget = SizedBox(
-        width: double.infinity, height: double.infinity, child: _widget);
+    _widget = SizedBox(width: double.infinity, child: _widget);
 
     return this;
   }


### PR DESCRIPTION
fullWidth method on Niku should be working as expected in method name.
Making widget full-width, not both full-height and full-width.