### PR TITLE
Add nullablitity to fontFamily method input

### DIFF
--- a/lib/widget/text.dart
+++ b/lib/widget/text.dart
@@ -550,7 +550,7 @@ class NikuText extends NikuCore {
   /// ```
   /// TextStyle(fontFamily: input)
   /// ```
-  NikuText fontFamily(String fontFamily) {
+  NikuText fontFamily(String? fontFamily) {
     _fontFamily = fontFamily;
 
     return this;
@@ -562,7 +562,7 @@ class NikuText extends NikuCore {
   /// ```
   /// TextStyle(fontFamilyFallback: input)
   /// ```
-  NikuText fontFamilyFallback(List<String> fontFamily) {
+  NikuText fontFamilyFallback(List<String>? fontFamily) {
     _fontFamilyFallback = fontFamily;
 
     return this;


### PR DESCRIPTION
This allow `fontFamily` that is `null` to be set as input for `NikuText.fontFamily` method.