### PR TITLE
feat(angleseeker): SliverToBox, and form key (2.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [2.2.3] - 2022/03/21
+Feature:
+  - Add `useTitle`, `useContent` to `NikuAlert`
+  - Add `sliverToBox`, `useForm`, and `formKey` to `Niku`
+
+Bugs fix:
+  - Set `borderColor` to `transparent` on calling `noUnderline` on `TextFormField`
+  - `.gap` not working with `Row`
+
 # [2.2.2] - 2022/03/21
 Bugs fix:
   - `NikuListTile.apply` not applying parent property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# [2.2.3] - 2022/03/21
+# [2.2.4] - 2022/03/23
+Feature:
+  - Add `sliverToBox`, `useForm`, and `formKey` to Parent Proxy
+
+# [2.2.3] - 2022/03/23
 Feature:
   - Add `useTitle`, `useContent` to `NikuAlert`
   - Add `sliverToBox`, `useForm`, and `formKey` to `Niku`

--- a/example/lib/version/2.2/aegle.dart
+++ b/example/lib/version/2.2/aegle.dart
@@ -27,65 +27,60 @@ class AegleSeeker extends HookWidget {
         ],
       ),
       body: n.Column([
-        // n.Text("AegleSeeker")..h4 = context,
-        // n.Button(Text("Toggle"))
-        //   ..onPressed = () {
-        //     toggle.value = !toggle.value;
-        //   },
-        // // --- Single Transition ---
-        // n.Box()
-        //   ..size = [100, 100]
-        //   ..useTransition<Color>(
-        //     value: toggle.value ? Colors.red.shade500 : Colors.blue.shade500,
-        //     builder: (child, value) => child..bg = value,
-        //     duration: Duration(milliseconds: 400),
-        //   )
-        //   ..useTransition<double>(
-        //     value: toggle.value ? 40.0 : 8.0,
-        //     builder: (v, value) => v..rounded = value,
-        //     curve: Curves.easeIn,
-        //   ),
-        // // --- Mulitple Transitions ---
-        // n.Box()
-        //   ..size = [100, 100]
-        //   ..useTransitions(
-        //     dependencies: [
-        //       toggle.value ? Colors.red : Colors.blue,
-        //       toggle.value ? 40.0 : 8.0,
-        //     ],
-        //     curve: Curves.easeOut,
-        //     builder: (child, deps) => child
-        //       ..bg = deps[0]
-        //       ..rounded = deps[1],
-        //   ),
-        // // --- New Widget ---
-        // n.ListView.children([
-        //   n.RadioListTile(false)
-        //     ..title = Text("Blue")
-        //     ..groupValue = toggle.value
-        //     ..onChanged = (value) {
-        //       toggle.value = value!;
-        //     },
-        //   n.RadioListTile(true)
-        //     ..title = Text("Red")
-        //     ..groupValue = toggle.value
-        //     ..onChanged = (value) {
-        //       toggle.value = value!;
-        //     },
-        // ])
-        //   ..shrinkWrap = true,
-        // n.Text("Hello")
-        //   ..usePlatform(
-        //     context,
-        //     iOS: (a) => a..color = Colors.red,
-        //     android: (a) => a..color = Colors.blue,
-        //   ),
+        n.Text("AegleSeeker")..h4 = context,
+        n.Button(Text("Toggle"))
+          ..onPressed = () {
+            toggle.value = !toggle.value;
+          },
+        // --- Single Transition ---
+        n.Box()
+          ..size = [100, 100]
+          ..useTransition<Color>(
+            value: toggle.value ? Colors.red.shade500 : Colors.blue.shade500,
+            builder: (child, value) => child..bg = value,
+            duration: Duration(milliseconds: 400),
+          )
+          ..useTransition<double>(
+            value: toggle.value ? 40.0 : 8.0,
+            builder: (v, value) => v..rounded = value,
+            curve: Curves.easeIn,
+          ),
+        // --- Mulitple Transitions ---
+        n.Box()
+          ..size = [100, 100]
+          ..useTransitions(
+            dependencies: [
+              toggle.value ? Colors.red : Colors.blue,
+              toggle.value ? 40.0 : 8.0,
+            ],
+            curve: Curves.easeOut,
+            builder: (child, deps) => child
+              ..bg = deps[0]
+              ..rounded = deps[1],
+          ),
+        // --- New Widget ---
+        n.ListView.children([
+          n.RadioListTile(false)
+            ..title = Text("Blue")
+            ..groupValue = toggle.value
+            ..onChanged = (value) {
+              toggle.value = value!;
+            },
+          n.RadioListTile(true)
+            ..title = Text("Red")
+            ..groupValue = toggle.value
+            ..onChanged = (value) {
+              toggle.value = value!;
+            },
+        ])
+          ..shrinkWrap = true,
+        n.Text("Hello")
+          ..usePlatform(
+            context,
+            iOS: (a) => a..color = Colors.red,
+            android: (a) => a..color = Colors.blue,
+          ),
         n.Text("Progress Bar"),
-        Progress(
-          progress: toggle.value ? 0 : 1,
-          color: Colors.blue,
-          background: Colors.grey.shade200,
-        ),
         n.Button(Text("Toggle"))
           ..onPressed = () {
             toggle.value = !toggle.value;
@@ -94,6 +89,15 @@ class AegleSeeker extends HookWidget {
           ..px = 24
           ..py = 12
           ..rounded = 8,
+        n.Row([
+          n.Box()
+            ..size = [40, 40]
+            ..bg = Colors.blue,
+          n.Box()
+            ..size = [40, 40]
+            ..bg = Colors.green,
+        ])
+          ..gap = 16,
       ])
         ..center
         ..w100

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.2.4"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.2.3"
   path:
     dependency: transitive
     description:

--- a/lib/macros/gap.dart
+++ b/lib/macros/gap.dart
@@ -4,21 +4,18 @@ abstract class GapMacro {
   List<Widget> children = [];
   double? gap;
 
-  List<Widget> $internalComposeGap(double? height) {
-    if (height == null || children.length == 0) return children;
+  List<Widget> $internalComposeGap(double? size) {
+    if (size == null || children.length == 0) return children;
 
     final childrenWithGap = [...children];
 
     for (int index = 1; index < children.length - 1; index++)
       childrenWithGap.insert(
         index * 2,
-        SizedBox(height: height),
+        SizedBox.square(dimension: size),
       );
 
-    childrenWithGap.insert(
-      1,
-      SizedBox(height: height),
-    );
+    childrenWithGap.insert(1, SizedBox.square(dimension: size));
 
     return childrenWithGap;
   }

--- a/lib/macros/nikuBuild.dart
+++ b/lib/macros/nikuBuild.dart
@@ -203,6 +203,25 @@ abstract class NikuBuildMacro<T extends Widget> {
   /// Cancel parent size inheritance by wrapping the widget with a [Wrap].
   get wrap => useParent((w) => Wrap(children: [w]));
 
+  void get sliverToBox => useParent((w) => SliverToBoxAdapter(child: w));
+
+  set formKey(Key v) => useParent((w) => Form(key: v, child: w));
+  void useForm({
+    Key? key,
+    AutovalidateMode? autovalidateMode,
+    Future<bool> Function()? onWillPop,
+    void Function()? onChanged,
+  }) =>
+      useParent(
+        (w) => Form(
+          key: key,
+          child: w,
+          autovalidateMode: autovalidateMode,
+          onWillPop: onWillPop,
+          onChanged: onChanged,
+        ),
+      );
+
   void useGesture({
     void Function(TapDownDetails)? tapDown,
     void Function(TapUpDetails)? tapUp,

--- a/lib/macros/nikuBuild.dart
+++ b/lib/macros/nikuBuild.dart
@@ -200,6 +200,9 @@ abstract class NikuBuildMacro<T extends Widget> {
   set height(double v) => useParent((w) => SizedBox(height: v, child: w));
   set h(double v) => useParent((w) => SizedBox(height: v, child: w));
 
+  /// Cancel parent size inheritance by wrapping the widget with a [Wrap].
+  get wrap => useParent((w) => Wrap(children: [w]));
+
   void useGesture({
     void Function(TapDownDetails)? tapDown,
     void Function(TapUpDetails)? tapUp,

--- a/lib/macros/widthHeight.dart
+++ b/lib/macros/widthHeight.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 abstract class WidthHeightMacro {
   double? width;
   double? height;

--- a/lib/objects/inputDecoration.dart
+++ b/lib/objects/inputDecoration.dart
@@ -236,6 +236,13 @@ class NikuInputDecoration
     errorBorder!.type = NikuInputBorderType.Underline;
   }
 
+  void get noUnderline {
+    _initializeAllBorder();
+
+    borderWidth = 0;
+    borderColor = Colors.transparent;
+  }
+
   void get outlined {
     _initializeAllBorder();
 

--- a/lib/proxy/textFormField.dart
+++ b/lib/proxy/textFormField.dart
@@ -387,6 +387,7 @@ extension TextFormFieldInputDecorationProxy on NikuTextFormField {
     _initializeAllBorder();
 
     decoration?.borderWidth = 0;
+    decoration?.borderColor = Colors.transparent;
   }
 
   void get outlined {

--- a/lib/widget/alert.dart
+++ b/lib/widget/alert.dart
@@ -154,6 +154,10 @@ class NikuAlert extends StatelessWidget
     this.cupertino = false,
   }) : super(key: key);
 
+  void useTitle(Widget Function() builder) => title = builder();
+  void useContent(Widget Function() builder) => content = builder();
+  void useActions(List<Widget> Function() builder) => actions = builder();
+
   factory NikuAlert.adaptive({
     Key? key,
     Widget? title,

--- a/lib/widget/niku.dart
+++ b/lib/widget/niku.dart
@@ -410,6 +410,7 @@ extension PropertyBuilder on Niku {
         child: _w,
       );
 
+  set formKey(Key v) => _w = Form(key: v, child: _w);
   void useForm({
     Key? key,
     AutovalidateMode? autovalidateMode,
@@ -520,6 +521,8 @@ extension PropertyBuilder on Niku {
       child: _w,
     );
   }
+
+  void get sliverToBox => _w = SliverToBoxAdapter(child: _w);
 
   set on(List<dynamic> dependencies) =>
       useChild((child) => NikuOn(() => child, dependencies));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: niku
 description: Property builder for styling Widget with SwiftUI like pattern
-version: 2.2.3
+version: 2.2.4
 homepage: https://github.com/saltyAom/niku
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: niku
 description: Property builder for styling Widget with SwiftUI like pattern
-version: 2.2.2
+version: 2.2.3
 homepage: https://github.com/saltyAom/niku
 
 environment:


### PR DESCRIPTION
# [2.2.4] - 2022/03/23
Feature:
  - Add `sliverToBox`, `useForm`, and `formKey` to Parent Proxy

# [2.2.3] - 2022/03/23
Feature:
  - Add `useTitle`, `useContent` to `NikuAlert`
  - Add `sliverToBox`, `useForm`, and `formKey` to `Niku`

Bugs fix:
  - Set `borderColor` to `transparent` on calling `noUnderline` on `TextFormField`
  - `.gap` not working with `Row`